### PR TITLE
fix: SESSION.CLOSE resets all session state

### DIFF
--- a/docs/sessions/commands/session-close.md
+++ b/docs/sessions/commands/session-close.md
@@ -26,8 +26,12 @@ The command performs a full session reset without closing the underlying network
 3. **MULTI State**: `MULTI` transaction state (queued commands, the MULTI flag) is reset
 4. **Watched Keys**: All keys being watched via `WATCH` are unwatched
 5. **Cursor ID Counter**: Reset to 1
-6. **Session Attributes**: All attributes (`reply_type`, `input_type`, `limit`, `object_id_format`) are reset to their
-   defaults
+6. **Session Defaults**: the configuration attributes (`reply_type`, `input_type`, `limit`, `object_id_format`) are
+   reset to their defaults, snapshot read goes back to off, the current namespace goes back to the default one, and
+   the client name, the library info and the authentication state are dropped
+
+The negotiated RESP version is kept, because the connection stays open. When the server runs with
+`auth.requirepass`, the client has to send `AUTH` again after this command.
 
 ## Examples
 
@@ -70,3 +74,28 @@ OK
 ```
 
 The `limit` attribute is reset to its default value (100).
+
+**Resetting snapshot read:**
+
+```kronotop
+> SNAPSHOTREAD ON
+OK
+
+> SESSION.CLOSE
+OK
+```
+
+Reads are serializable again. The next transaction on this connection does not inherit snapshot isolation.
+
+**Resetting the current namespace:**
+
+```kronotop
+> NAMESPACE USE global.staging
+OK
+
+> SESSION.CLOSE
+OK
+
+> NAMESPACE CURRENT
+global
+```

--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -23,6 +23,10 @@ A session tracks the following categories of state:
 - **Active FoundationDB transaction**, at most one at a time, with its post-commit hooks and version counter
 - **Query cursors**, three independent pools for read, delete, and update operations
 - **Cursor ID counter**, a monotonically increasing integer scoped to the session
+- **Current namespace**, set with `NAMESPACE USE`
+- **Snapshot read setting**, set with `SNAPSHOTREAD`
+- **Client name and library info**, set with `CLIENT SETNAME` and `CLIENT SETINFO`
+- **Authentication state**, when `auth.requirepass` is set
 
 All of this state is connection-scoped and invisible to other sessions.
 
@@ -108,9 +112,14 @@ Watched keys (`WATCH`) are also session-scoped. `SESSION.CLOSE` unwatches all ke
 3. **Reset MULTI state**: queued commands are discarded and the MULTI flag is cleared
 4. **Unwatch all keys**: every key in the session's watch list is released
 5. **Reset the cursor ID counter**: the next cursor will start at 1 again
-6. **Restore default attributes**: all four session attributes revert to their configured defaults
+6. **Restore session defaults**: the four configuration attributes revert to their configured defaults, the
+   snapshot read setting goes back to off, the current namespace goes back to the default one, and the client
+   name, the library info and the authentication state are dropped
 
-After `SESSION.CLOSE` returns `OK`, the session is indistinguishable from a freshly opened connection.
+After `SESSION.CLOSE` returns `OK`, the session is back to the state of a freshly opened connection, with two
+things to keep in mind. The negotiated RESP version stays as it is, because the connection itself is not
+closed. And if the server runs with `auth.requirepass`, the client has to send `AUTH` again before the next
+command.
 
 ```kronotop
 > SESSION.ATTRIBUTE SET limit 50

--- a/docs/transactions/index.md
+++ b/docs/transactions/index.md
@@ -116,8 +116,8 @@ The setting applies to ZMap read commands (`ZGET`, `ZGETI64`, `ZGETF64`, `ZGETD1
 `ZGETRANGESIZE`) and `BUCKET.QUERY`. Mutation commands (`BUCKET.INSERT`, `BUCKET.DELETE`, `BUCKET.UPDATE`)
 always use serializable reads regardless of the setting.
 
-The setting is session-scoped and persists until explicitly changed with `SNAPSHOTREAD OFF` or the session ends. It can
-be toggled at any time, regardless of whether a transaction is currently active.
+The setting is session-scoped and persists until explicitly changed with `SNAPSHOTREAD OFF`, until `SESSION.CLOSE`, or
+until the session ends. It can be toggled at any time, regardless of whether a transaction is currently active.
 
 ## Cross-Namespace Transactions
 

--- a/kronotop/src/main/java/com/kronotop/core/handlers/session/SessionCloseHandler.java
+++ b/kronotop/src/main/java/com/kronotop/core/handlers/session/SessionCloseHandler.java
@@ -34,8 +34,12 @@ import com.kronotop.watcher.Watcher;
  *   <li>Cleans up Redis MULTI transaction state</li>
  *   <li>Unwatches all watched keys</li>
  *   <li>Resets cursor ID counter to 1</li>
- *   <li>Resets all configuration attributes to defaults</li>
+ *   <li>Restores the session defaults: configuration attributes, snapshot read, readonly and
+ *       authentication flags, current namespace, open namespace cache and client attributes</li>
  * </ul>
+ * <p>
+ * The negotiated RESP version is kept, because the connection stays open. When
+ * {@code auth.requirepass} is set, the client must authenticate again after this command.
  */
 @Command(SessionCloseMessage.COMMAND)
 @MaximumParameterCount(SessionCloseMessage.MAXIMUM_PARAMETER_COUNT)
@@ -81,7 +85,7 @@ public class SessionCloseHandler implements Handler {
         // 5. Reset cursor ID counter to 1
         session.resetCursorId();
 
-        // 6. Reset all configuration attributes to defaults
+        // 6. Restore all session defaults
         session.resetSessionAttributes();
 
         response.writeOK();

--- a/kronotop/src/main/java/com/kronotop/server/Session.java
+++ b/kronotop/src/main/java/com/kronotop/server/Session.java
@@ -104,12 +104,10 @@ public class Session {
         Long clientId = ClientIDGenerator.getAndIncrement();
         channel.attr(SessionAttributes.CLIENT_ID).set(clientId);
         channel.attr(SessionAttributes.OPEN_NAMESPACES).set(new ConcurrentHashMap<>());
-        channel.attr(SessionAttributes.CURRENT_NAMESPACE).set(context.getDefaultNamespace());
         channel.attr(SessionAttributes.CLIENT_ATTRIBUTES).set(new HashMap<>());
         channel.attr(SessionAttributes.BUCKET_READ_QUERY_CONTEXTS).set(new HashMap<>());
         channel.attr(SessionAttributes.BUCKET_DELETE_QUERY_CONTEXTS).set(new HashMap<>());
         channel.attr(SessionAttributes.BUCKET_UPDATE_QUERY_CONTEXTS).set(new HashMap<>());
-        channel.attr(SessionAttributes.READONLY).set(false);
         channel.attr(SessionAttributes.QUEUED_COMMANDS).set(new ArrayList<>());
         channel.attr(SessionAttributes.MULTI).set(false);
         channel.attr(SessionAttributes.MULTI_DISCARDED).set(false);
@@ -256,7 +254,10 @@ public class Session {
     }
 
     /**
-     * Resets all configurable session attributes to their default values from the configuration.
+     * Restores every session default: the configurable attributes, the snapshot read, readonly and
+     * authentication flags, the current namespace, the open namespace cache and the client attributes.
+     * <p>
+     * The containers themselves are created once by the session and only emptied here.
      */
     public void resetSessionAttributes() {
         String replyType = context.getConfig().getString("session_attributes.reply_type");
@@ -270,6 +271,17 @@ public class Session {
 
         String objectIdFormat = context.getConfig().getString("bucket.object_id_format");
         channel.attr(SessionAttributes.OBJECT_ID_FORMAT).set(ObjectIdFormat.valueOf(objectIdFormat.toUpperCase()));
+
+        // SNAPSHOTREAD OFF stores null, so the reset uses the same value.
+        channel.attr(SessionAttributes.SNAPSHOT_READ).set(null);
+        channel.attr(SessionAttributes.READONLY).set(false);
+        channel.attr(SessionAttributes.AUTH).set(false);
+        channel.attr(SessionAttributes.CURRENT_NAMESPACE).set(context.getDefaultNamespace());
+
+        // Empty the maps in place. SessionStore.invalidateOpenNamespaces walks all sessions and
+        // touches this map, so replacing it here would leave that scan on a discarded instance.
+        channel.attr(SessionAttributes.OPEN_NAMESPACES).get().clear();
+        channel.attr(SessionAttributes.CLIENT_ATTRIBUTES).get().clear();
     }
 
     /**

--- a/kronotop/src/test/java/com/kronotop/core/handlers/session/SessionCloseHandlerAuthTest.java
+++ b/kronotop/src/test/java/com/kronotop/core/handlers/session/SessionCloseHandlerAuthTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023-2026 Burak Sezer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kronotop.core.handlers.session;
+
+import com.kronotop.BaseHandlerTest;
+import com.kronotop.commands.KronotopCommandBuilder;
+import com.kronotop.commands.redis.RedisCommandBuilder;
+import com.kronotop.server.Response;
+import com.kronotop.server.resp3.ErrorRedisMessage;
+import com.kronotop.server.resp3.SimpleStringRedisMessage;
+import io.lettuce.core.codec.StringCodec;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class SessionCloseHandlerAuthTest extends BaseHandlerTest {
+
+    @Override
+    protected String getConfigFileName() {
+        return "auth-requirepass-test.conf";
+    }
+
+    private void authenticate() {
+        RedisCommandBuilder<String, String> cmd = new RedisCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        cmd.auth("devpass").encode(buf);
+        Object response = runCommand(channel, buf);
+        assertInstanceOf(SimpleStringRedisMessage.class, response);
+        assertEquals(Response.OK, ((SimpleStringRedisMessage) response).content());
+    }
+
+    private Object ping() {
+        RedisCommandBuilder<String, String> cmd = new RedisCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        cmd.ping().encode(buf);
+        return runCommand(channel, buf);
+    }
+
+    private void closeSession() {
+        KronotopCommandBuilder<String, String> cmd = new KronotopCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        cmd.sessionClose().encode(buf);
+        Object response = runCommand(channel, buf);
+        assertInstanceOf(SimpleStringRedisMessage.class, response);
+        assertEquals(Response.OK, ((SimpleStringRedisMessage) response).content());
+    }
+
+    @Test
+    void shouldRequireAuthenticationAfterClose() {
+        // Behavior: SESSION.CLOSE clears the authentication flag when auth.requirepass is set.
+        authenticate();
+        assertInstanceOf(SimpleStringRedisMessage.class, ping());
+
+        closeSession();
+
+        Object response = ping();
+        assertInstanceOf(ErrorRedisMessage.class, response);
+        assertEquals("NOAUTH Authentication required.", ((ErrorRedisMessage) response).content());
+    }
+
+    @Test
+    void shouldAuthenticateAgainAfterClose() {
+        // Behavior: the same connection is usable again after it authenticates following SESSION.CLOSE.
+        authenticate();
+        closeSession();
+
+        authenticate();
+        assertInstanceOf(SimpleStringRedisMessage.class, ping());
+    }
+}

--- a/kronotop/src/test/java/com/kronotop/core/handlers/session/SessionCloseHandlerTest.java
+++ b/kronotop/src/test/java/com/kronotop/core/handlers/session/SessionCloseHandlerTest.java
@@ -18,12 +18,12 @@ package com.kronotop.core.handlers.session;
 
 import com.kronotop.BaseHandlerTest;
 import com.kronotop.bucket.BSONUtil;
-import com.kronotop.commands.BucketCommandBuilder;
-import com.kronotop.commands.BucketQueryArgs;
-import com.kronotop.commands.KronotopCommandBuilder;
-import com.kronotop.commands.SessionAttributeKeywords;
+import com.kronotop.commands.*;
+import com.kronotop.commands.redis.RedisCommandBuilder;
+import com.kronotop.namespace.handlers.Namespace;
 import com.kronotop.server.RESPVersion;
 import com.kronotop.server.Response;
+import com.kronotop.server.SessionAttributes;
 import com.kronotop.server.resp3.*;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.codec.StringCodec;
@@ -222,6 +222,121 @@ class SessionCloseHandlerTest extends BaseHandlerTest {
             ArrayRedisMessage list = (ArrayRedisMessage) response;
             assertTrue(containsAttributeValue(list, "limit", 100L));
         }
+    }
+
+    @Test
+    void shouldResetSnapshotReadAfterClose() {
+        // Behavior: SESSION.CLOSE turns snapshot read off, so a pooled connection cannot leak it.
+        KronotopCommandBuilder<String, String> cmd = new KronotopCommandBuilder<>(StringCodec.ASCII);
+
+        {
+            ByteBuf buf = Unpooled.buffer();
+            cmd.snapshotRead(SnapshotReadArgs.Builder.on()).encode(buf);
+            Object response = runCommand(channel, buf);
+            assertInstanceOf(SimpleStringRedisMessage.class, response);
+            assertEquals(Response.OK, ((SimpleStringRedisMessage) response).content());
+        }
+        assertTrue(channel.attr(SessionAttributes.SNAPSHOT_READ).get());
+
+        closeSession();
+
+        assertNull(channel.attr(SessionAttributes.SNAPSHOT_READ).get());
+    }
+
+    @Test
+    void shouldResetReadonlyFlagAfterClose() {
+        // Behavior: SESSION.CLOSE clears the readonly flag set by the READONLY command.
+        {
+            // READONLY has no command builder method, so send the raw RESP frame.
+            ByteBuf buf = Unpooled.buffer();
+            buf.writeBytes("*1\r\n$8\r\nREADONLY\r\n".getBytes(StandardCharsets.US_ASCII));
+            Object response = runCommand(channel, buf);
+            assertInstanceOf(SimpleStringRedisMessage.class, response);
+            assertEquals(Response.OK, ((SimpleStringRedisMessage) response).content());
+        }
+        assertTrue(channel.attr(SessionAttributes.READONLY).get());
+
+        closeSession();
+
+        assertFalse(channel.attr(SessionAttributes.READONLY).get());
+    }
+
+    @Test
+    void shouldResetCurrentNamespaceAfterClose() {
+        // Behavior: SESSION.CLOSE switches the session back to the default namespace.
+        KronotopCommandBuilder<String, String> cmd = new KronotopCommandBuilder<>(StringCodec.ASCII);
+        String target = TEST_NAMESPACE + "." + namespace;
+
+        {
+            ByteBuf buf = Unpooled.buffer();
+            cmd.namespaceCreate(target).encode(buf);
+            Object response = runCommand(channel, buf);
+            assertInstanceOf(SimpleStringRedisMessage.class, response);
+            assertEquals(Response.OK, ((SimpleStringRedisMessage) response).content());
+        }
+
+        {
+            ByteBuf buf = Unpooled.buffer();
+            cmd.namespaceUse(target).encode(buf);
+            Object response = runCommand(channel, buf);
+            assertInstanceOf(SimpleStringRedisMessage.class, response);
+            assertEquals(Response.OK, ((SimpleStringRedisMessage) response).content());
+        }
+        assertEquals(target, currentNamespace());
+
+        closeSession();
+
+        assertEquals(TEST_NAMESPACE, currentNamespace());
+    }
+
+    @Test
+    void shouldClearOpenNamespacesAfterClose() {
+        // Behavior: SESSION.CLOSE empties the open namespace cache of the session.
+        ZMapCommandBuilder<String, String> zmap = new ZMapCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        zmap.zset("session-close-key", "value").encode(buf);
+        Object response = runCommand(channel, buf);
+        assertInstanceOf(SimpleStringRedisMessage.class, response);
+
+        Map<String, Namespace> openNamespaces = channel.attr(SessionAttributes.OPEN_NAMESPACES).get();
+        assertFalse(openNamespaces.isEmpty());
+
+        closeSession();
+
+        assertTrue(channel.attr(SessionAttributes.OPEN_NAMESPACES).get().isEmpty());
+    }
+
+    @Test
+    void shouldClearClientAttributesAfterClose() {
+        // Behavior: SESSION.CLOSE drops the client name set with CLIENT SETNAME.
+        RedisCommandBuilder<String, String> redis = new RedisCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        redis.clientSetname("app-1").encode(buf);
+        Object response = runCommand(channel, buf);
+        assertInstanceOf(SimpleStringRedisMessage.class, response);
+        assertEquals("app-1", channel.attr(SessionAttributes.CLIENT_ATTRIBUTES).get().get("name"));
+
+        closeSession();
+
+        assertTrue(channel.attr(SessionAttributes.CLIENT_ATTRIBUTES).get().isEmpty());
+    }
+
+    private void closeSession() {
+        KronotopCommandBuilder<String, String> cmd = new KronotopCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        cmd.sessionClose().encode(buf);
+        Object response = runCommand(channel, buf);
+        assertInstanceOf(SimpleStringRedisMessage.class, response);
+        assertEquals(Response.OK, ((SimpleStringRedisMessage) response).content());
+    }
+
+    private String currentNamespace() {
+        KronotopCommandBuilder<String, String> cmd = new KronotopCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        cmd.namespaceCurrent().encode(buf);
+        Object response = runCommand(channel, buf);
+        assertInstanceOf(FullBulkStringRedisMessage.class, response);
+        return ((FullBulkStringRedisMessage) response).content().toString(StandardCharsets.UTF_8);
     }
 
     private boolean containsAttributeValue(ArrayRedisMessage list, String attributeName, long expectedValue) {


### PR DESCRIPTION
PR for #16

- `SESSION.CLOSE` resets all session state.
- Update and clarify the documentation. 