### PR TITLE
fix: Null replies ignore the negotiated protocol version

### DIFF
--- a/kronotop/src/main/java/com/kronotop/bucket/PipelineExplainer.java
+++ b/kronotop/src/main/java/com/kronotop/bucket/PipelineExplainer.java
@@ -18,6 +18,8 @@ package com.kronotop.bucket;
 
 import com.kronotop.bucket.index.SingleFieldIndexDefinition;
 import com.kronotop.bucket.pipeline.*;
+import com.kronotop.server.RESPUtil;
+import com.kronotop.server.RESPVersion;
 import com.kronotop.server.resp3.*;
 import io.netty.buffer.Unpooled;
 
@@ -35,12 +37,13 @@ public class PipelineExplainer {
     private static final int PLANNER_VERSION = 1;
 
     /**
-     * Explains a pipeline node as a RESP3 map structure.
+     * Explains a pipeline node as a map structure.
      *
-     * @param node the pipeline node to explain
+     * @param node    the pipeline node to explain
+     * @param version the protocol version the plan is rendered for
      * @return a map of RedisMessage key-value pairs representing the plan
      */
-    public static Map<RedisMessage, RedisMessage> explain(PipelineNode node) {
+    public static Map<RedisMessage, RedisMessage> explain(PipelineNode node, RESPVersion version) {
         Map<RedisMessage, RedisMessage> result = new LinkedHashMap<>();
         result.put(key("planner_version"), intValue(PLANNER_VERSION));
 
@@ -52,18 +55,18 @@ public class PipelineExplainer {
         result.put(key("id"), intValue(node.id()));
 
         switch (node) {
-            case IndexScanNode scan -> explainIndexScan(result, scan);
-            case FullScanNode scan -> explainFullScan(result, scan);
-            case RangeScanNode scan -> explainRangeScan(result, scan);
-            case CompoundIndexScanNode scan -> explainCompoundIndexScan(result, scan);
-            case UnionNode union -> explainUnion(result, union);
-            case OrderedConcatNode orderedConcat -> explainOrderedConcat(result, orderedConcat);
-            case TransformWithResidualPredicateNode transform -> explainTransform(result, transform);
+            case IndexScanNode scan -> explainIndexScan(result, scan, version);
+            case FullScanNode scan -> explainFullScan(result, scan, version);
+            case RangeScanNode scan -> explainRangeScan(result, scan, version);
+            case CompoundIndexScanNode scan -> explainCompoundIndexScan(result, scan, version);
+            case UnionNode union -> explainUnion(result, union, version);
+            case OrderedConcatNode orderedConcat -> explainOrderedConcat(result, orderedConcat, version);
+            case TransformWithResidualPredicateNode transform -> explainTransform(result, transform, version);
             default -> result.put(key("details"), value("Unknown node type"));
         }
 
         if (node.next() != null) {
-            result.put(key("next"), new MapRedisMessage(explain(node.next())));
+            result.put(key("next"), new MapRedisMessage(explain(node.next(), version)));
         }
 
         return result;
@@ -76,11 +79,11 @@ public class PipelineExplainer {
      * @return a list of RedisMessage representing the plan as flattened key-value pairs
      */
     public static List<RedisMessage> explainAsArray(PipelineNode node) {
-        return flattenMap(explain(node));
+        return flattenMap(explain(node, RESPVersion.RESP2));
     }
 
     /**
-     * Wraps the explanation in an ArrayRedisMessage for direct RESP response.
+     * Wraps the explanation in an ArrayRedisMessage for direct RESP2 response.
      *
      * @param node the pipeline node to explain
      * @return an ArrayRedisMessage containing the flattened plan
@@ -96,22 +99,22 @@ public class PipelineExplainer {
      * @return a MapRedisMessage containing the plan
      */
     public static MapRedisMessage explainAsMapMessage(PipelineNode node) {
-        return new MapRedisMessage(explain(node));
+        return new MapRedisMessage(explain(node, RESPVersion.RESP3));
     }
 
-    private static void explainIndexScan(Map<RedisMessage, RedisMessage> result, IndexScanNode scan) {
+    private static void explainIndexScan(Map<RedisMessage, RedisMessage> result, IndexScanNode scan, RESPVersion version) {
         result.put(key("scanType"), value("INDEX_SCAN"));
         result.put(key("index"), value(scan.getIndexDefinition().name()));
         result.put(key("selector"), value(scan.predicate().selector()));
         result.put(key("operator"), value(scan.predicate().op().name()));
-        result.put(key("operand"), formatOperand(scan.predicate().operand()));
+        result.put(key("operand"), formatOperand(scan.predicate().operand(), version));
         addIndexCollation(result, scan.getIndexDefinition());
     }
 
-    private static void explainFullScan(Map<RedisMessage, RedisMessage> result, FullScanNode scan) {
+    private static void explainFullScan(Map<RedisMessage, RedisMessage> result, FullScanNode scan, RESPVersion version) {
         result.put(key("scanType"), value("FULL_SCAN"));
         result.put(key("index"), value(scan.getIndexDefinition().name()));
-        result.put(key("predicate"), explainPredicateAsMessage(scan.predicate()));
+        result.put(key("predicate"), explainPredicateAsMessage(scan.predicate(), version));
         if (scan.isCollationMismatch()) {
             result.put(key("collation_mismatch"), boolValue(true));
             if (scan.getRejectedIndex() != null) {
@@ -120,18 +123,18 @@ public class PipelineExplainer {
         }
     }
 
-    private static void explainRangeScan(Map<RedisMessage, RedisMessage> result, RangeScanNode scan) {
+    private static void explainRangeScan(Map<RedisMessage, RedisMessage> result, RangeScanNode scan, RESPVersion version) {
         result.put(key("scanType"), value("RANGE_SCAN"));
         result.put(key("index"), value(scan.getIndexDefinition().name()));
         result.put(key("selector"), value(scan.predicate().selector()));
-        result.put(key("lowerBound"), formatOperand(scan.predicate().lowerBound()));
-        result.put(key("upperBound"), formatOperand(scan.predicate().upperBound()));
+        result.put(key("lowerBound"), formatOperand(scan.predicate().lowerBound(), version));
+        result.put(key("upperBound"), formatOperand(scan.predicate().upperBound(), version));
         result.put(key("includeLower"), boolValue(scan.predicate().includeLower()));
         result.put(key("includeUpper"), boolValue(scan.predicate().includeUpper()));
         addIndexCollation(result, scan.getIndexDefinition());
     }
 
-    private static void explainCompoundIndexScan(Map<RedisMessage, RedisMessage> result, CompoundIndexScanNode scan) {
+    private static void explainCompoundIndexScan(Map<RedisMessage, RedisMessage> result, CompoundIndexScanNode scan, RESPVersion version) {
         result.put(key("scanType"), value("COMPOUND_INDEX_SCAN"));
         result.put(key("index"), value(scan.indexDefinition().name()));
 
@@ -140,7 +143,7 @@ public class PipelineExplainer {
             Map<RedisMessage, RedisMessage> filterMap = new LinkedHashMap<>();
             filterMap.put(key("selector"), value(filter.selector()));
             filterMap.put(key("operator"), value(filter.op().name()));
-            filterMap.put(key("operand"), formatOperand(filter.operand()));
+            filterMap.put(key("operand"), formatOperand(filter.operand(), version));
             filterMessages.add(new MapRedisMessage(filterMap));
         }
         result.put(key("filters"), new ArrayRedisMessage(filterMessages));
@@ -149,34 +152,34 @@ public class PipelineExplainer {
         }
     }
 
-    private static void explainUnion(Map<RedisMessage, RedisMessage> result, UnionNode union) {
+    private static void explainUnion(Map<RedisMessage, RedisMessage> result, UnionNode union, RESPVersion version) {
         result.put(key("operation"), value("UNION"));
-        result.put(key("children"), explainChildrenAsMessage(union.children()));
+        result.put(key("children"), explainChildrenAsMessage(union.children(), version));
     }
 
-    private static void explainOrderedConcat(Map<RedisMessage, RedisMessage> result, OrderedConcatNode orderedConcat) {
+    private static void explainOrderedConcat(Map<RedisMessage, RedisMessage> result, OrderedConcatNode orderedConcat, RESPVersion version) {
         result.put(key("operation"), value("ORDERED_CONCAT"));
-        result.put(key("children"), explainChildrenAsMessage(orderedConcat.children()));
+        result.put(key("children"), explainChildrenAsMessage(orderedConcat.children(), version));
     }
 
-    private static void explainTransform(Map<RedisMessage, RedisMessage> result, TransformWithResidualPredicateNode transform) {
+    private static void explainTransform(Map<RedisMessage, RedisMessage> result, TransformWithResidualPredicateNode transform, RESPVersion version) {
         result.put(key("operation"), value("FILTER"));
-        result.put(key("predicate"), explainPredicateAsMessage(transform.predicate()));
+        result.put(key("predicate"), explainPredicateAsMessage(transform.predicate(), version));
     }
 
-    private static ArrayRedisMessage explainChildrenAsMessage(List<PipelineNode> children) {
+    private static ArrayRedisMessage explainChildrenAsMessage(List<PipelineNode> children, RESPVersion version) {
         List<RedisMessage> childMessages = new ArrayList<>();
         for (PipelineNode child : children) {
-            childMessages.add(new MapRedisMessage(explain(child)));
+            childMessages.add(new MapRedisMessage(explain(child, version)));
         }
         return new ArrayRedisMessage(childMessages);
     }
 
-    private static RedisMessage explainPredicateAsMessage(ResidualPredicateNode predicate) {
-        return new MapRedisMessage(explainPredicate(predicate));
+    private static RedisMessage explainPredicateAsMessage(ResidualPredicateNode predicate, RESPVersion version) {
+        return new MapRedisMessage(explainPredicate(predicate, version));
     }
 
-    private static Map<RedisMessage, RedisMessage> explainPredicate(ResidualPredicateNode predicate) {
+    private static Map<RedisMessage, RedisMessage> explainPredicate(ResidualPredicateNode predicate, RESPVersion version) {
         Map<RedisMessage, RedisMessage> result = new LinkedHashMap<>();
 
         switch (predicate) {
@@ -184,15 +187,15 @@ public class PipelineExplainer {
                 result.put(key("type"), value("PREDICATE"));
                 result.put(key("selector"), value(p.selector()));
                 result.put(key("operator"), value(p.op().name()));
-                result.put(key("operand"), formatOperand(p.operand()));
+                result.put(key("operand"), formatOperand(p.operand(), version));
             }
             case ResidualAndNode andNode -> {
                 result.put(key("type"), value("AND"));
-                result.put(key("children"), explainPredicateChildrenAsMessage(andNode.children()));
+                result.put(key("children"), explainPredicateChildrenAsMessage(andNode.children(), version));
             }
             case ResidualOrNode orNode -> {
                 result.put(key("type"), value("OR"));
-                result.put(key("children"), explainPredicateChildrenAsMessage(orNode.children()));
+                result.put(key("children"), explainPredicateChildrenAsMessage(orNode.children(), version));
             }
             case AlwaysTruePredicate ignored -> result.put(key("type"), value("ALWAYS_TRUE"));
             default -> result.put(key("type"), value("UNKNOWN"));
@@ -201,10 +204,10 @@ public class PipelineExplainer {
         return result;
     }
 
-    private static ArrayRedisMessage explainPredicateChildrenAsMessage(List<ResidualPredicateNode> children) {
+    private static ArrayRedisMessage explainPredicateChildrenAsMessage(List<ResidualPredicateNode> children, RESPVersion version) {
         List<RedisMessage> childMessages = new ArrayList<>();
         for (ResidualPredicateNode child : children) {
-            childMessages.add(new MapRedisMessage(explainPredicate(child)));
+            childMessages.add(new MapRedisMessage(explainPredicate(child, version)));
         }
         return new ArrayRedisMessage(childMessages);
     }
@@ -286,9 +289,9 @@ public class PipelineExplainer {
         return value ? BooleanRedisMessage.TRUE : BooleanRedisMessage.FALSE;
     }
 
-    private static RedisMessage formatOperand(Object operand) {
+    private static RedisMessage formatOperand(Object operand, RESPVersion version) {
         if (operand == null) {
-            return NullRedisMessage.INSTANCE;
+            return RESPUtil.nullMessage(version);
         }
         return switch (operand) {
             case String s -> value(s);

--- a/kronotop/src/main/java/com/kronotop/server/KronotopChannelDuplexHandler.java
+++ b/kronotop/src/main/java/com/kronotop/server/KronotopChannelDuplexHandler.java
@@ -25,7 +25,6 @@ import com.kronotop.internal.ProtocolMessageUtil;
 import com.kronotop.server.impl.RESP3Request;
 import com.kronotop.server.impl.RESP3Response;
 import com.kronotop.server.impl.TransactionResponse;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.stash.StashService;
 import com.kronotop.stash.handlers.transactions.protocol.DiscardMessage;
 import com.kronotop.stash.handlers.transactions.protocol.ExecMessage;
@@ -260,8 +259,8 @@ public class KronotopChannelDuplexHandler extends ChannelDuplexHandler {
     }
 
     private void executeRedisTransaction(Session session) {
-        Response response = new RESP3Response(session.getCtx());
-        TransactionResponse transactionResponse = new TransactionResponse(session.getCtx());
+        Response response = new RESP3Response(session.getCtx(), session.protocolVersion());
+        TransactionResponse transactionResponse = new TransactionResponse(session.getCtx(), session.protocolVersion());
         transactionLock.writeLock().lock();
         try {
             Attribute<Boolean> redisMultiDiscarded = session.attr(SessionAttributes.MULTI_DISCARDED);
@@ -277,7 +276,7 @@ public class KronotopChannelDuplexHandler extends ChannelDuplexHandler {
                         // If keys were modified between when they were WATCHed
                         // and when the EXEC was received, the entire transaction
                         // will be aborted instead.
-                        response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                        response.writeNULL();
                         return;
                     }
                 }
@@ -417,7 +416,7 @@ public class KronotopChannelDuplexHandler extends ChannelDuplexHandler {
         Session session = Session.extractSessionFromChannel(ctx.channel());
 
         Request request = new RESP3Request(session, message);
-        Response response = new RESP3Response(ctx);
+        Response response = new RESP3Response(ctx, session.protocolVersion());
 
         if (logCommandForDebugging) {
             String command = readCommandAsString(request);

--- a/kronotop/src/main/java/com/kronotop/server/RESPUtil.java
+++ b/kronotop/src/main/java/com/kronotop/server/RESPUtil.java
@@ -17,6 +17,8 @@
 package com.kronotop.server;
 
 import com.kronotop.server.resp3.FullBulkStringRedisMessage;
+import com.kronotop.server.resp3.NullRedisMessage;
+import com.kronotop.server.resp3.RedisMessage;
 import io.netty.buffer.Unpooled;
 
 import java.nio.charset.StandardCharsets;
@@ -39,5 +41,15 @@ public class RESPUtil {
     public static FullBulkStringRedisMessage bulkString(String input) {
         String value = input != null ? input : "";
         return wrapBytes(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Returns the null message for the given protocol version. RESP3 has its own null type,
+     * RESP2 encodes null as a bulk string with a length of -1.
+     */
+    public static RedisMessage nullMessage(RESPVersion version) {
+        return version == RESPVersion.RESP3
+                ? NullRedisMessage.INSTANCE
+                : FullBulkStringRedisMessage.NULL_INSTANCE;
     }
 }

--- a/kronotop/src/main/java/com/kronotop/server/Response.java
+++ b/kronotop/src/main/java/com/kronotop/server/Response.java
@@ -145,7 +145,9 @@ public interface Response {
     /**
      * Writes a NULL Redis response message to the client.
      * <p>
-     * The method does not return a value.
+     * The wire form depends on the protocol version negotiated by the session. Handlers must use this
+     * method instead of writing a null message directly, so that both RESP2 and RESP3 clients get a
+     * reply they can parse.
      */
     void writeNULL();
 
@@ -198,7 +200,7 @@ public interface Response {
      * Flushes the response messages to the client.
      * <p>
      * This method is used to flush the response messages to the client. It sends the buffered messages to the client
-     * for processing. If there are no response messages to flush, it sends a NULL_INSTANCE message.
+     * for processing. If there are no response messages to flush, it sends a null reply.
      * <p>
      * If the response messages are an array of Redis messages, it sends an ArrayRedisMessage. If the response messages
      * are an "OK" Redis message, it sends a FullBulkStringRedisMessage with the value "OK". If the response messages are

--- a/kronotop/src/main/java/com/kronotop/server/impl/RESP3Response.java
+++ b/kronotop/src/main/java/com/kronotop/server/impl/RESP3Response.java
@@ -19,6 +19,8 @@ package com.kronotop.server.impl;
 import com.apple.foundationdb.FDBException;
 import com.kronotop.KronotopException;
 import com.kronotop.server.RESPError;
+import com.kronotop.server.RESPUtil;
+import com.kronotop.server.RESPVersion;
 import com.kronotop.server.Response;
 import com.kronotop.server.resp3.*;
 import com.kronotop.transaction.TransactionUtil;
@@ -38,9 +40,11 @@ import java.util.concurrent.CompletionException;
  */
 public class RESP3Response implements Response {
     private final ChannelHandlerContext ctx;
+    private final RESPVersion protocolVersion;
 
-    public RESP3Response(ChannelHandlerContext ctx) {
+    public RESP3Response(ChannelHandlerContext ctx, RESPVersion protocolVersion) {
         this.ctx = ctx;
+        this.protocolVersion = protocolVersion;
     }
 
     /**
@@ -164,12 +168,11 @@ public class RESP3Response implements Response {
     /**
      * Writes a NULL Redis message to the client.
      * <p>
-     * This method is used to write a NULL message to the client as a response.
-     * It calls the {@link ChannelHandlerContext#writeAndFlush(Object)} method with the {@link NullRedisMessage#INSTANCE}.
+     * The wire form depends on the protocol version negotiated by the session.
      */
     @Override
     public void writeNULL() {
-        ctx.writeAndFlush(NullRedisMessage.INSTANCE);
+        ctx.writeAndFlush(RESPUtil.nullMessage(protocolVersion));
     }
 
     /**
@@ -330,8 +333,6 @@ public class RESP3Response implements Response {
      * @param prefix  the prefix of the error message
      * @param content the content of the error message
      * @param <T>     the type of the prefix
-     * @param prefix  the content to be written before the error message
-     * @param content the content of the error message
      * @throws NullPointerException if the prefix or content is null
      */
     @Override
@@ -343,14 +344,7 @@ public class RESP3Response implements Response {
     }
 
     /**
-     * Flushes the response messages to the client.
-     * <p>
-     * This method is used to flush the response messages to the client. It sends the buffered messages to the client
-     * for processing. If there are no response messages to flush, it sends a NULL_INSTANCE message.
-     * <p>
-     * If the response messages are an array of Redis messages, it sends an ArrayRedisMessage. If the response messages
-     * are an "OK" Redis message, it sends a FullBulkStringRedisMessage with the value "OK". If the response messages are
-     * a "QUEUED" Redis message, it sends a FullBulkStringRedisMessage with the value "QUEUED".
+     * Flushes any pending messages to the client.
      */
     @Override
     public void flush() {

--- a/kronotop/src/main/java/com/kronotop/server/impl/TransactionResponse.java
+++ b/kronotop/src/main/java/com/kronotop/server/impl/TransactionResponse.java
@@ -19,6 +19,8 @@ package com.kronotop.server.impl;
 import com.apple.foundationdb.FDBException;
 import com.kronotop.KronotopException;
 import com.kronotop.server.RESPError;
+import com.kronotop.server.RESPUtil;
+import com.kronotop.server.RESPVersion;
 import com.kronotop.server.Response;
 import com.kronotop.server.resp3.*;
 import com.kronotop.transaction.TransactionUtil;
@@ -40,9 +42,11 @@ import java.util.concurrent.CompletionException;
 public class TransactionResponse implements Response {
     private final ChannelHandlerContext ctx;
     private final List<RedisMessage> messages = new ArrayList<>();
+    private final RESPVersion protocolVersion;
 
-    public TransactionResponse(ChannelHandlerContext ctx) {
+    public TransactionResponse(ChannelHandlerContext ctx, RESPVersion protocolVersion) {
         this.ctx = ctx;
+        this.protocolVersion = protocolVersion;
     }
 
     /**
@@ -148,11 +152,11 @@ public class TransactionResponse implements Response {
     /**
      * Adds a NULL Redis response message to the list of response messages.
      * <p>
-     * The method does not return a value.
+     * The wire form depends on the protocol version negotiated by the session.
      */
     @Override
     public void writeNULL() {
-        messages.add(NullRedisMessage.INSTANCE);
+        messages.add(RESPUtil.nullMessage(protocolVersion));
     }
 
     /**
@@ -315,14 +319,13 @@ public class TransactionResponse implements Response {
     }
 
     /**
-     * Flushes the messages in the TransactionResponse object.
-     * If the messages list is empty, it writes a NULL_INSTANCE message to the channel and flushes it.
-     * If the messages list is not empty, it writes an ArrayRedisMessage containing the messages list to the channel and flushes it.
+     * Flushes the buffered messages to the client.
+     * An empty list is written as a null reply, otherwise the messages are wrapped in an array.
      */
     @Override
     public void flush() {
         if (messages.isEmpty()) {
-            ctx.writeAndFlush(FullBulkStringRedisMessage.NULL_INSTANCE);
+            ctx.writeAndFlush(RESPUtil.nullMessage(protocolVersion));
             return;
         }
         ctx.writeAndFlush(new ArrayRedisMessage(messages));

--- a/kronotop/src/main/java/com/kronotop/stash/handlers/generic/RandomKeyHandler.java
+++ b/kronotop/src/main/java/com/kronotop/stash/handlers/generic/RandomKeyHandler.java
@@ -24,7 +24,6 @@ import com.kronotop.server.Response;
 import com.kronotop.server.annotation.Command;
 import com.kronotop.server.annotation.MaximumParameterCount;
 import com.kronotop.server.annotation.MinimumParameterCount;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.stash.StashService;
 import com.kronotop.stash.handlers.BaseHandler;
 import com.kronotop.stash.handlers.generic.protocol.RandomKeyMessage;
@@ -56,7 +55,7 @@ public class RandomKeyHandler extends BaseHandler implements Handler {
     public void execute(Request request, Response response) {
         Collection<StashShard> shards = service.getServiceContext().shards().values();
         if (shards.isEmpty()) {
-            response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+            response.writeNULL();
             return;
         }
         List<Integer> shardIds = new ArrayList<>();
@@ -67,7 +66,7 @@ public class RandomKeyHandler extends BaseHandler implements Handler {
         }
 
         if (shardIds.isEmpty()) {
-            response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+            response.writeNULL();
             return;
         }
 
@@ -79,7 +78,7 @@ public class RandomKeyHandler extends BaseHandler implements Handler {
             ByteBuf buf = Unpooled.wrappedBuffer(randomKey.getBytes(StandardCharsets.UTF_8));
             response.write(buf);
         } catch (NoSuchElementException e) {
-            response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+            response.writeNULL();
         }
     }
 }

--- a/kronotop/src/main/java/com/kronotop/stash/handlers/hash/HGetHandler.java
+++ b/kronotop/src/main/java/com/kronotop/stash/handlers/hash/HGetHandler.java
@@ -24,7 +24,6 @@ import com.kronotop.server.Response;
 import com.kronotop.server.annotation.Command;
 import com.kronotop.server.annotation.MaximumParameterCount;
 import com.kronotop.server.annotation.MinimumParameterCount;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.stash.StashService;
 import com.kronotop.stash.handlers.BaseHandler;
 import com.kronotop.stash.handlers.hash.protocol.HGetMessage;
@@ -61,14 +60,14 @@ public class HGetHandler extends BaseHandler implements Handler {
         try {
             StashValueContainer container = shard.storage().get(hgetMessage.getKey());
             if (container == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
             checkStashValueKind(container, StashValueKind.HASH);
 
             HashFieldValue hashField = container.hash().get(hgetMessage.getField());
             if (hashField == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
 

--- a/kronotop/src/main/java/com/kronotop/stash/handlers/hash/HMGetHandler.java
+++ b/kronotop/src/main/java/com/kronotop/stash/handlers/hash/HMGetHandler.java
@@ -19,6 +19,7 @@ package com.kronotop.stash.handlers.hash;
 import com.kronotop.cluster.sharding.ShardStatus;
 import com.kronotop.server.Handler;
 import com.kronotop.server.MessageTypes;
+import com.kronotop.server.RESPUtil;
 import com.kronotop.server.Request;
 import com.kronotop.server.Response;
 import com.kronotop.server.annotation.Command;
@@ -57,6 +58,7 @@ public class HMGetHandler extends BaseHandler implements Handler {
         HMGetMessage hmgetMessage = request.attr(MessageTypes.HMGET).get();
 
         List<RedisMessage> upperList = new ArrayList<>();
+        RedisMessage nullMessage = RESPUtil.nullMessage(request.getSession().protocolVersion());
         StashShard shard = service.findShard(hmgetMessage.getKey(), ShardStatus.READONLY);
         ReadWriteLock lock = shard.striped().get(hmgetMessage.getKey());
         lock.readLock().lock();
@@ -64,14 +66,14 @@ public class HMGetHandler extends BaseHandler implements Handler {
             StashValueContainer container = shard.storage().get(hmgetMessage.getKey());
             if (container == null) {
                 for (int i = 0; i < hmgetMessage.getFields().size(); i++) {
-                    upperList.add(FullBulkStringRedisMessage.NULL_INSTANCE);
+                    upperList.add(nullMessage);
                 }
             } else {
                 checkStashValueKind(container, StashValueKind.HASH);
                 for (String field : hmgetMessage.getFields()) {
                     HashFieldValue hashField = container.hash().get(field);
                     if (hashField.value() == null) {
-                        upperList.add(FullBulkStringRedisMessage.NULL_INSTANCE);
+                        upperList.add(nullMessage);
                         continue;
                     }
 

--- a/kronotop/src/main/java/com/kronotop/stash/handlers/hash/HRandFieldHandler.java
+++ b/kronotop/src/main/java/com/kronotop/stash/handlers/hash/HRandFieldHandler.java
@@ -109,7 +109,7 @@ public class HRandFieldHandler extends BaseHandler implements Handler {
         try {
             StashValueContainer container = shard.storage().get(hrandfieldMessage.getKey());
             if (container == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
             checkStashValueKind(container, StashValueKind.HASH);

--- a/kronotop/src/main/java/com/kronotop/stash/handlers/string/GetDelHandler.java
+++ b/kronotop/src/main/java/com/kronotop/stash/handlers/string/GetDelHandler.java
@@ -24,7 +24,6 @@ import com.kronotop.server.Response;
 import com.kronotop.server.annotation.Command;
 import com.kronotop.server.annotation.MaximumParameterCount;
 import com.kronotop.server.annotation.MinimumParameterCount;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.stash.StashService;
 import com.kronotop.stash.handlers.string.protocol.GetDelMessage;
 import com.kronotop.stash.storage.StashShard;
@@ -90,7 +89,7 @@ public class GetDelHandler extends BaseStringHandler implements Handler {
         }
 
         if (previous == null) {
-            response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+            response.writeNULL();
             return;
         }
 

--- a/kronotop/src/main/java/com/kronotop/stash/handlers/string/GetHandler.java
+++ b/kronotop/src/main/java/com/kronotop/stash/handlers/string/GetHandler.java
@@ -21,7 +21,6 @@ import com.kronotop.server.*;
 import com.kronotop.server.annotation.Command;
 import com.kronotop.server.annotation.MaximumParameterCount;
 import com.kronotop.server.annotation.MinimumParameterCount;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.stash.StashService;
 import com.kronotop.stash.handlers.string.protocol.GetMessage;
 import com.kronotop.stash.storage.StashShard;
@@ -55,14 +54,14 @@ public class GetHandler extends BaseStringHandler implements Handler {
         try {
             StashValueContainer container = shard.storage().get(message.getKey());
             if (container == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
             if (!container.kind().equals(StashValueKind.STRING)) {
                 throw new WrongTypeException();
             }
             if (evictStringIfNeeded(container, shard, message.getKey())) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
             ByteBuf buf = Unpooled.wrappedBuffer(container.string().value());

--- a/kronotop/src/main/java/com/kronotop/stash/handlers/string/GetSetHandler.java
+++ b/kronotop/src/main/java/com/kronotop/stash/handlers/string/GetSetHandler.java
@@ -24,7 +24,6 @@ import com.kronotop.server.Response;
 import com.kronotop.server.annotation.Command;
 import com.kronotop.server.annotation.MaximumParameterCount;
 import com.kronotop.server.annotation.MinimumParameterCount;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.stash.StashService;
 import com.kronotop.stash.handlers.string.protocol.GetSetMessage;
 import com.kronotop.stash.storage.StashShard;
@@ -88,7 +87,7 @@ public class GetSetHandler extends BaseStringHandler implements Handler {
         }
 
         if (previous == null) {
-            response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+            response.writeNULL();
             return;
         }
 

--- a/kronotop/src/main/java/com/kronotop/stash/handlers/string/MGetHandler.java
+++ b/kronotop/src/main/java/com/kronotop/stash/handlers/string/MGetHandler.java
@@ -19,6 +19,7 @@ package com.kronotop.stash.handlers.string;
 import com.kronotop.cluster.sharding.ShardStatus;
 import com.kronotop.server.Handler;
 import com.kronotop.server.MessageTypes;
+import com.kronotop.server.RESPUtil;
 import com.kronotop.server.Request;
 import com.kronotop.server.Response;
 import com.kronotop.server.annotation.Command;
@@ -57,6 +58,7 @@ public class MGetHandler extends BaseStringHandler implements Handler {
 
         Iterable<ReadWriteLock> locks = shard.striped().bulkGet(mgetMessage.getKeys());
         List<RedisMessage> result = new ArrayList<>();
+        RedisMessage nullMessage = RESPUtil.nullMessage(request.getSession().protocolVersion());
         try {
             for (ReadWriteLock lock : locks) {
                 lock.readLock().lock();
@@ -65,12 +67,12 @@ public class MGetHandler extends BaseStringHandler implements Handler {
             for (String key : mgetMessage.getKeys()) {
                 StashValueContainer container = shard.storage().get(key);
                 if (container == null) {
-                    result.add(FullBulkStringRedisMessage.NULL_INSTANCE);
+                    result.add(nullMessage);
                     continue;
                 }
 
                 if (!(container.kind().equals(StashValueKind.STRING))) {
-                    result.add(FullBulkStringRedisMessage.NULL_INSTANCE);
+                    result.add(nullMessage);
                     continue;
                 }
 

--- a/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetD128Handler.java
+++ b/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetD128Handler.java
@@ -69,7 +69,7 @@ public class ZGetD128Handler extends BaseZMapHandler implements Handler {
             return get(tr, key, TransactionUtil.isSnapshotRead(session)).join();
         }, (value) -> {
             if (value == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
             Decimal128 current = ZMapNumericValueCodec.decodeD128(value);

--- a/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetF64Handler.java
+++ b/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetF64Handler.java
@@ -22,7 +22,6 @@ import com.kronotop.server.*;
 import com.kronotop.server.annotation.Command;
 import com.kronotop.server.annotation.MaximumParameterCount;
 import com.kronotop.server.annotation.MinimumParameterCount;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.transaction.TransactionUtil;
 import com.kronotop.zmap.BaseZMapHandler;
 import com.kronotop.zmap.ZMapNumericValueCodec;
@@ -64,7 +63,7 @@ public class ZGetF64Handler extends BaseZMapHandler implements Handler {
             return get(tr, key, TransactionUtil.isSnapshotRead(session)).join();
         }, (value) -> {
             if (value == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
             double result = ZMapNumericValueCodec.decodeF64(value);

--- a/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetHandler.java
+++ b/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetHandler.java
@@ -66,7 +66,7 @@ public class ZGetHandler extends BaseZMapHandler implements Handler {
             return future.join();
         }, (value) -> {
             if (value == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
             ByteBuf buf = Unpooled.wrappedBuffer(value);

--- a/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetI64Handler.java
+++ b/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetI64Handler.java
@@ -22,7 +22,6 @@ import com.kronotop.server.*;
 import com.kronotop.server.annotation.Command;
 import com.kronotop.server.annotation.MaximumParameterCount;
 import com.kronotop.server.annotation.MinimumParameterCount;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.transaction.TransactionUtil;
 import com.kronotop.zmap.BaseZMapHandler;
 import com.kronotop.zmap.ZMapNumericValueCodec;
@@ -64,7 +63,7 @@ public class ZGetI64Handler extends BaseZMapHandler implements Handler {
             return get(tr, key, TransactionUtil.isSnapshotRead(session)).join();
         }, (value) -> {
             if (value == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
             long result = ZMapNumericValueCodec.decodeI64(value);

--- a/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetKeyHandler.java
+++ b/kronotop/src/main/java/com/kronotop/zmap/handlers/ZGetKeyHandler.java
@@ -24,7 +24,6 @@ import com.kronotop.server.*;
 import com.kronotop.server.annotation.Command;
 import com.kronotop.server.annotation.MaximumParameterCount;
 import com.kronotop.server.annotation.MinimumParameterCount;
-import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.transaction.TransactionUtil;
 import com.kronotop.zmap.BaseZMapHandler;
 import com.kronotop.zmap.ZMapService;
@@ -74,7 +73,7 @@ public class ZGetKeyHandler extends BaseZMapHandler implements Handler {
             return new Result(subspace, future.join());
         }, (result) -> {
             if (result.value() == null) {
-                response.writeFullBulkString(FullBulkStringRedisMessage.NULL_INSTANCE);
+                response.writeNULL();
                 return;
             }
 

--- a/kronotop/src/test/java/com/kronotop/bucket/pipeline/PipelineExplainerTest.java
+++ b/kronotop/src/test/java/com/kronotop/bucket/pipeline/PipelineExplainerTest.java
@@ -21,9 +21,11 @@ import com.kronotop.bucket.bql.ast.Int32Val;
 import com.kronotop.bucket.bql.ast.StringVal;
 import com.kronotop.bucket.index.*;
 import com.kronotop.bucket.planner.Operator;
+import com.kronotop.server.RESPVersion;
 import com.kronotop.server.resp3.ArrayRedisMessage;
 import com.kronotop.server.resp3.FullBulkStringRedisMessage;
 import com.kronotop.server.resp3.MapRedisMessage;
+import com.kronotop.server.resp3.NullRedisMessage;
 import com.kronotop.server.resp3.RedisMessage;
 import org.bson.BsonType;
 import org.jspecify.annotations.NonNull;
@@ -51,7 +53,7 @@ class PipelineExplainerTest {
 
     @Test
     void shouldReturnPlannerVersionForNullNode() {
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(null);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(null, RESPVersion.RESP3);
         assertEquals(1, result.size());
         assertTrue(containsKey(result, "planner_version"));
     }
@@ -62,7 +64,7 @@ class PipelineExplainerTest {
         IndexScanPredicate predicate = new IndexScanPredicate(1, "age", Operator.EQ, new Operand.Literal(new Int32Val(25)));
         IndexScanNode node = new IndexScanNode(1, indexDef, predicate);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -76,7 +78,7 @@ class PipelineExplainerTest {
         AlwaysTruePredicate predicate = new AlwaysTruePredicate();
         FullScanNode node = new TestFullScanNode(1, predicate);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -93,7 +95,7 @@ class PipelineExplainerTest {
                 true, false);
         RangeScanNode node = new TestRangeScanNode(1, indexDef, predicate);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -112,7 +114,7 @@ class PipelineExplainerTest {
         IndexScanNode child2 = new IndexScanNode(2, indexDef, predicate2);
         UnionNode unionNode = new UnionNode(3, List.of(child1, child2));
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(unionNode);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(unionNode, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "operation"));
@@ -124,7 +126,7 @@ class PipelineExplainerTest {
         ResidualPredicate residualPredicate = new ResidualPredicate(1, "status", Operator.EQ, new Operand.Literal(new StringVal("active")));
         TransformWithResidualPredicateNode transformNode = new TransformWithResidualPredicateNode(1, residualPredicate);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(transformNode);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(transformNode, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "operation"));
@@ -142,7 +144,7 @@ class PipelineExplainerTest {
 
         scanNode.connectNext(transformNode);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(scanNode);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(scanNode, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "next"));
@@ -179,7 +181,7 @@ class PipelineExplainerTest {
         ResidualAndNode andNode = new ResidualAndNode(List.of(pred1, pred2));
         TransformWithResidualPredicateNode transformNode = new TransformWithResidualPredicateNode(3, andNode);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(transformNode);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(transformNode, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "predicate"));
@@ -192,7 +194,7 @@ class PipelineExplainerTest {
         ResidualOrNode orNode = new ResidualOrNode(List.of(pred1, pred2));
         TransformWithResidualPredicateNode transformNode = new TransformWithResidualPredicateNode(3, orNode);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(transformNode);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(transformNode, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "predicate"));
@@ -203,7 +205,7 @@ class PipelineExplainerTest {
         AlwaysTruePredicate alwaysTrue = new AlwaysTruePredicate();
         TransformWithResidualPredicateNode transformNode = new TransformWithResidualPredicateNode(1, alwaysTrue);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(transformNode);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(transformNode, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "predicate"));
@@ -220,7 +222,7 @@ class PipelineExplainerTest {
         IndexScanNode child2 = new IndexScanNode(2, indexDef, predicate2);
         OrderedConcatNode orderedConcatNode = new OrderedConcatNode(3, List.of(child1, child2));
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(orderedConcatNode);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(orderedConcatNode, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "nodeType"));
@@ -248,7 +250,7 @@ class PipelineExplainerTest {
         TransformWithResidualPredicateNode transformNode = new TransformWithResidualPredicateNode(3, residualPredicate);
         orderedConcatNode.connectNext(transformNode);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(orderedConcatNode);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(orderedConcatNode, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "operation"));
@@ -269,7 +271,7 @@ class PipelineExplainerTest {
         );
         CompoundIndexScanNode node = new CompoundIndexScanNode(1, indexDef, filters);
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "scanType"));
@@ -282,7 +284,7 @@ class PipelineExplainerTest {
         // Behavior: A compound index scan with EQ + GT filters should list both filters in the filters array.
         CompoundIndexScanNode node = getCompoundIndexScanNode();
 
-        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node);
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(node, RESPVersion.RESP3);
 
         assertNotNull(result);
         assertTrue(containsKey(result, "scanType"));
@@ -305,6 +307,28 @@ class PipelineExplainerTest {
         Map<RedisMessage, RedisMessage> secondFilter = ((MapRedisMessage) filtersArray.children().get(1)).children();
         assertEquals("score", getStringValue(secondFilter, "selector"));
         assertEquals("GT", getStringValue(secondFilter, "operator"));
+    }
+
+    @Test
+    void shouldFormatNullOperandAsBulkStringNullWhenRESP2() {
+        // Behavior: an unbounded range has a null operand, which a RESP2 client must receive as $-1.
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(unboundedRangeScanNode(), RESPVersion.RESP2);
+
+        assertEquals(FullBulkStringRedisMessage.NULL_INSTANCE, getValueForKey(result, "lowerBound"));
+    }
+
+    @Test
+    void shouldFormatNullOperandAsNullTypeWhenRESP3() {
+        // Behavior: the same null operand is rendered as the RESP3 null type on a RESP3 session.
+        Map<RedisMessage, RedisMessage> result = PipelineExplainer.explain(unboundedRangeScanNode(), RESPVersion.RESP3);
+
+        assertEquals(NullRedisMessage.INSTANCE, getValueForKey(result, "lowerBound"));
+    }
+
+    private RangeScanNode unboundedRangeScanNode() {
+        SingleFieldIndexDefinition indexDef = SingleFieldIndexDefinition.create("age_idx", "age", BsonType.INT32, false, IndexStatus.WAITING);
+        RangeScanPredicate predicate = new RangeScanPredicate("age", null, new Operand.Literal(new Int32Val(65)), false, false);
+        return new TestRangeScanNode(1, indexDef, predicate);
     }
 
     private boolean containsKey(Map<RedisMessage, RedisMessage> map, String keyName) {

--- a/kronotop/src/test/java/com/kronotop/server/RESPUtilTest.java
+++ b/kronotop/src/test/java/com/kronotop/server/RESPUtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023-2026 Burak Sezer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kronotop.server;
+
+import com.kronotop.server.resp3.FullBulkStringRedisMessage;
+import com.kronotop.server.resp3.NullRedisMessage;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RESPUtilTest {
+
+    @Test
+    void shouldReturnBulkStringNullForRESP2() {
+        // Behavior: RESP2 has no null type, null is a bulk string with a length of -1.
+        assertEquals(FullBulkStringRedisMessage.NULL_INSTANCE, RESPUtil.nullMessage(RESPVersion.RESP2));
+    }
+
+    @Test
+    void shouldReturnNullMessageForRESP3() {
+        // Behavior: RESP3 has its own null type.
+        assertEquals(NullRedisMessage.INSTANCE, RESPUtil.nullMessage(RESPVersion.RESP3));
+    }
+}

--- a/kronotop/src/test/java/com/kronotop/server/RespResponseTest.java
+++ b/kronotop/src/test/java/com/kronotop/server/RespResponseTest.java
@@ -52,7 +52,7 @@ class RespResponseTest {
     @Test
     void shouldWriteRedisMessage() {
         // Create a RespResponse object and associate it with the channel
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
 
         // Call the writeOK() method to add a simple 'OK' string to the response
         response.writeRedisMessage(new SimpleStringRedisMessage("Hello!"));
@@ -66,7 +66,7 @@ class RespResponseTest {
     @Test
     void shouldWriteOK() {
         // Create a RespResponse object and associate it with the channel
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
 
         // Call the writeOK() method to add a simple 'OK' string to the response
         response.writeOK();
@@ -80,7 +80,7 @@ class RespResponseTest {
     @Disabled("This test is skipped because EmbeddedChannel.flush doesn't work as expected.")
     @Test
     void shouldWriteQUEUED() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeQUEUED();
         response.flush();
 
@@ -92,7 +92,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteInteger() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeInteger(100);
         RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
         assertInstanceOf(IntegerRedisMessage.class, redisMessage);
@@ -102,7 +102,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteDouble() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeDouble(100);
         RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
         assertInstanceOf(DoubleRedisMessage.class, redisMessage);
@@ -112,7 +112,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteArray() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         SimpleStringRedisMessage first = new SimpleStringRedisMessage("first message");
         DoubleRedisMessage second = new DoubleRedisMessage(100);
         List<RedisMessage> array = new ArrayList<>();
@@ -139,7 +139,7 @@ class RespResponseTest {
         Map<RedisMessage, RedisMessage> map = new HashMap<>();
         map.put(key, value);
 
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeMap(map);
 
         RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
@@ -154,7 +154,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteBoolean() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         {
             response.writeBoolean(true);
             RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
@@ -173,18 +173,28 @@ class RespResponseTest {
     }
 
     @Test
-    void shouldWriteNULL() {
-        RESP3Response response = new RESP3Response(ctx);
+    void shouldWriteNullAsNullTypeWhenRESP3() {
+        // Behavior: writeNULL emits the RESP3 null type on a RESP3 session.
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeNULL();
         RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
         assertInstanceOf(NullRedisMessage.class, redisMessage);
-        NullRedisMessage nullRedisMessage = (NullRedisMessage) redisMessage;
-        assertEquals(NullRedisMessage.INSTANCE, nullRedisMessage);
+        assertEquals(NullRedisMessage.INSTANCE, redisMessage);
+    }
+
+    @Test
+    void shouldWriteNullAsBulkStringWhenRESP2() {
+        // Behavior: writeNULL emits the RESP2 null bulk string on a RESP2 session.
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP2);
+        response.writeNULL();
+        RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
+        assertInstanceOf(FullBulkStringRedisMessage.class, redisMessage);
+        assertEquals(FullBulkStringRedisMessage.NULL_INSTANCE, redisMessage);
     }
 
     @Test
     void shouldWriteBigNumber() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         {
             response.writeBigNumber(BigInteger.valueOf(100));
             RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
@@ -212,7 +222,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteVerbatimString() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
 
         ByteBuf content = Unpooled.buffer();
         content.writeBytes("message".getBytes(StandardCharsets.UTF_8));
@@ -238,7 +248,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteError() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeError("error message");
 
         RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
@@ -249,7 +259,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteErrorWithPrefix() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeError(RESPError.CROSSSLOT, "error message");
 
         RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
@@ -260,7 +270,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteBulkError() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeBulkError("error message");
 
         RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
@@ -277,7 +287,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteBulkErrorWithPrefix() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
         response.writeBulkError(RESPError.CROSSSLOT, "error message");
 
         RedisMessage redisMessage = ctx.embeddedChannel().readOutbound();
@@ -295,7 +305,7 @@ class RespResponseTest {
     @Test
     void shouldWriteSimpleString() {
         // Create a RespResponse object and associate it with the channel
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
 
         response.writeSimpleString("message");
 
@@ -308,7 +318,7 @@ class RespResponseTest {
     @Test
     void shouldWriteFullBulkString() {
         // Create a RespResponse object and associate it with the channel
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
 
         ByteBuf content = Unpooled.copiedBuffer("message", CharsetUtil.UTF_8);
         response.writeFullBulkString(new FullBulkStringRedisMessage(content));
@@ -329,7 +339,7 @@ class RespResponseTest {
     @Test
     void shouldWrite() {
         // Create a RespResponse object and associate it with the channel
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
 
         ByteBuf content = Unpooled.copiedBuffer("message", CharsetUtil.UTF_8);
         response.write(content);
@@ -349,7 +359,7 @@ class RespResponseTest {
 
     @Test
     void shouldWriteSet() {
-        RESP3Response response = new RESP3Response(ctx);
+        RESP3Response response = new RESP3Response(ctx, RESPVersion.RESP3);
 
         Set<RedisMessage> set = new HashSet<>();
         set.add(new SimpleStringRedisMessage("foobar"));

--- a/kronotop/src/test/java/com/kronotop/stash/handlers/hash/HGetHandlerTest.java
+++ b/kronotop/src/test/java/com/kronotop/stash/handlers/hash/HGetHandlerTest.java
@@ -17,7 +17,9 @@
 package com.kronotop.stash.handlers.hash;
 
 import com.kronotop.commands.redis.RedisCommandBuilder;
+import com.kronotop.server.RESPVersion;
 import com.kronotop.server.resp3.FullBulkStringRedisMessage;
+import com.kronotop.server.resp3.NullRedisMessage;
 import com.kronotop.stash.handlers.BaseStashHandlerTest;
 import io.lettuce.core.codec.StringCodec;
 import io.netty.buffer.ByteBuf;
@@ -48,6 +50,19 @@ public class HGetHandlerTest extends BaseStashHandlerTest {
             FullBulkStringRedisMessage actualMessage = (FullBulkStringRedisMessage) msg;
             assertEquals("value", actualMessage.content().toString(CharsetUtil.US_ASCII));
         }
+    }
+
+    @Test
+    void shouldReturnNullTypeWhenProtocolIsRESP3() {
+        // Behavior: HGET on a missing key replies with the RESP3 null type after HELLO 3.
+        switchProtocol(RESPVersion.RESP3);
+
+        RedisCommandBuilder<String, String> cmd = new RedisCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        cmd.hget("mykey", "field").encode(buf);
+
+        Object msg = runCommand(channel, buf);
+        assertInstanceOf(NullRedisMessage.class, msg);
     }
 
     @Test

--- a/kronotop/src/test/java/com/kronotop/stash/handlers/string/GetHandlerTest.java
+++ b/kronotop/src/test/java/com/kronotop/stash/handlers/string/GetHandlerTest.java
@@ -18,8 +18,10 @@ package com.kronotop.stash.handlers.string;
 
 
 import com.kronotop.commands.redis.RedisCommandBuilder;
+import com.kronotop.server.RESPVersion;
 import com.kronotop.server.Response;
 import com.kronotop.server.resp3.FullBulkStringRedisMessage;
+import com.kronotop.server.resp3.NullRedisMessage;
 import com.kronotop.server.resp3.SimpleStringRedisMessage;
 import com.kronotop.stash.handlers.BaseStashHandlerTest;
 import io.lettuce.core.codec.StringCodec;
@@ -45,6 +47,19 @@ class GetHandlerTest extends BaseStashHandlerTest {
         assertInstanceOf(FullBulkStringRedisMessage.class, msg);
         FullBulkStringRedisMessage actualMessage = (FullBulkStringRedisMessage) msg;
         assertEquals(FullBulkStringRedisMessage.NULL_INSTANCE, actualMessage);
+    }
+
+    @Test
+    void shouldReturnNullTypeWhenProtocolIsRESP3() {
+        // Behavior: GET on a missing key replies with the RESP3 null type after HELLO 3.
+        switchProtocol(RESPVersion.RESP3);
+
+        RedisCommandBuilder<String, String> cmd = new RedisCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        cmd.get("mykey").encode(buf);
+
+        Object msg = runCommand(channel, buf);
+        assertInstanceOf(NullRedisMessage.class, msg);
     }
 
     @Test

--- a/kronotop/src/test/java/com/kronotop/stash/handlers/string/MGetHandlerTest.java
+++ b/kronotop/src/test/java/com/kronotop/stash/handlers/string/MGetHandlerTest.java
@@ -18,9 +18,11 @@ package com.kronotop.stash.handlers.string;
 
 
 import com.kronotop.commands.redis.RedisCommandBuilder;
+import com.kronotop.server.RESPVersion;
 import com.kronotop.server.Response;
 import com.kronotop.server.resp3.ArrayRedisMessage;
 import com.kronotop.server.resp3.FullBulkStringRedisMessage;
+import com.kronotop.server.resp3.NullRedisMessage;
 import com.kronotop.server.resp3.RedisMessage;
 import com.kronotop.server.resp3.SimpleStringRedisMessage;
 import com.kronotop.stash.handlers.BaseStashHandlerTest;
@@ -70,6 +72,25 @@ public class MGetHandlerTest extends BaseStashHandlerTest {
             assertInstanceOf(FullBulkStringRedisMessage.class, redisMessage);
             FullBulkStringRedisMessage item = (FullBulkStringRedisMessage) redisMessage;
             assertEquals(FullBulkStringRedisMessage.NULL_INSTANCE, item);
+        }
+    }
+
+    @Test
+    void shouldReturnNullTypeInsideArrayWhenProtocolIsRESP3() {
+        // Behavior: missing keys inside the MGET array use the RESP3 null type after HELLO 3.
+        switchProtocol(RESPVersion.RESP3);
+
+        RedisCommandBuilder<String, String> cmd = new RedisCommandBuilder<>(StringCodec.ASCII);
+        ByteBuf buf = Unpooled.buffer();
+        cmd.mget(getKeys()).encode(buf);
+
+        Object msg = runCommand(channel, buf);
+        assertInstanceOf(ArrayRedisMessage.class, msg);
+        ArrayRedisMessage actualMessage = (ArrayRedisMessage) msg;
+        assertEquals(3, actualMessage.children().size());
+
+        for (RedisMessage redisMessage : actualMessage.children()) {
+            assertInstanceOf(NullRedisMessage.class, redisMessage);
         }
     }
 

--- a/kronotop/src/test/java/com/kronotop/zmap/handlers/ZGetHandlerTest.java
+++ b/kronotop/src/test/java/com/kronotop/zmap/handlers/ZGetHandlerTest.java
@@ -19,8 +19,10 @@ package com.kronotop.zmap.handlers;
 import com.kronotop.BaseHandlerTest;
 import com.kronotop.commands.KronotopCommandBuilder;
 import com.kronotop.commands.ZMapCommandBuilder;
+import com.kronotop.server.RESPVersion;
 import com.kronotop.server.Response;
 import com.kronotop.server.resp3.FullBulkStringRedisMessage;
+import com.kronotop.server.resp3.NullRedisMessage;
 import com.kronotop.server.resp3.SimpleStringRedisMessage;
 import io.lettuce.core.codec.StringCodec;
 import io.netty.buffer.ByteBuf;
@@ -89,6 +91,21 @@ class ZGetHandlerTest extends BaseHandlerTest {
             FullBulkStringRedisMessage actualMessage = (FullBulkStringRedisMessage) response;
             assertEquals("value", actualMessage.content().toString(CharsetUtil.US_ASCII));
         }
+    }
+
+    @Test
+    void shouldReturnNullTypeWhenProtocolIsRESP3() {
+        // Behavior: ZGET on a missing key replies with the RESP3 null type after HELLO 3.
+        switchProtocol(RESPVersion.RESP3);
+
+        EmbeddedChannel channel = getChannel();
+        ZMapCommandBuilder<String, String> cmd = new ZMapCommandBuilder<>(StringCodec.ASCII);
+
+        ByteBuf buf = Unpooled.buffer();
+        cmd.zget("key").encode(buf);
+
+        Object response = runCommand(channel, buf);
+        assertInstanceOf(NullRedisMessage.class, response);
     }
 
     @Test


### PR DESCRIPTION
PR for #18 

- `RESPUtil.nullMessage` added to normalize null message generation, 
- `Response` implementations are now aware of the negotiated protocol version,
- `writeNULL` method is used to return `null` response in handlers. `writeNULL` methods decides the wire format.  